### PR TITLE
actions: add option to skip import testing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -145,8 +145,10 @@ jobs:
           UPTEST_DATASOURCE_PATH: .work/uptest-datasource.yaml
           UPTEST_UPDATE_PARAMETER: ""
           UPTEST_DEFAULT_TIMEOUT: ${{ vars.UPTEST_DEFAULT_TIMEOUT }}
+          UPTEST_SKIP_IMPORT: ${{ vars.UPTEST_SKIP_IMPORT }}
         run: |
           echo "Timeout is $UPTEST_DEFAULT_TIMEOUT"
+          echo "UPTEST_SKIP_IMPORT is $UPTEST_SKIP_IMPORT"
           mkdir -p .work && echo "${{ secrets.UPTEST_DATASOURCE }}" > .work/uptest-datasource.yaml
           make e2e
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Some services(looking at RDS) will fail import testing [workflow](https://github.com/opentelekomcloud/provider-opentelekomcloud/actions/runs/22149040820).  By default we should test imports, but need an option to be able to skip those tests for services which are known for not playing nicely with terraform import
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
