### PR TITLE
docs: only activate modern APIs in default quick start installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,15 @@ helm repo update
 ```
 
 Finally, install Crossplane using Helm:
+#### Install the T Cloud Public provider
+> [!NOTE]
+> The provider ships hundreds of ManagedResouces by default, which will increase the load on `kube-apiserver`. Please consider using [MRAP](https://docs.crossplane.io/latest/managed-resources/managed-resource-activation-policies/) to only activate needed resources. Crossplane by [default](https://docs.crossplane.io/latest/managed-resources/managed-resource-activation-policies/#activate-everything-default-behavior) activates all controllers and APIs, even the legacy ones. If you are just started using Crossplane we recommend installing with `provider.defaultActivations={"*.opentelekomcloud.m.crossplane.io"} ` to avoid a large number of legacy resources.
+
 
 ```console
-helm install crossplane --namespace crossplane-system crossplane-stable/crossplane 
+helm install crossplane crossplane-stable/crossplane \
+  --set provider.defaultActivations={"*.opentelekomcloud.m.crossplane.io"} \
+-n crossplane-system
 ```
 
 After installation, verify that Crossplane is running correctly:
@@ -55,8 +61,6 @@ kubectl -n crossplane-system wait --for=condition=Available deployment --all --t
 ```
 
 #### Install the T Cloud Public provider
-> [!NOTE]
-> The provider ships hundreds of ManagedResouces by default, which will increase the load on `kube-apiserver`. Please consider using [MRAP](https://docs.crossplane.io/latest/managed-resources/managed-resource-activation-policies/) to only activate needed resources.
 
 Install the provider by using the following command after changing the image tag to the [latest release](https://marketplace.upbound.io/providers/opentelekomcloud/provider-opentelekomcloud):
 
@@ -67,7 +71,7 @@ kind: Provider
 metadata:
   name: provider-opentelekomcloud
 spec:
-  package: xpkg.upbound.io/opentelekomcloud/provider-opentelekomcloud:v0.7.0
+  package: xpkg.upbound.io/opentelekomcloud/provider-opentelekomcloud:v0.9.0
 EOF
 ```
 

--- a/docs/mrap.md
+++ b/docs/mrap.md
@@ -1,0 +1,25 @@
+# Managed Resource Activation Policies
+
+When installing Crossplane with default values it will activate all available APIs and controllers. In most cases this will lead hundreds of unused and unnecessary resources in `kube-api`.
+If you are just starting with Crossplane we recommend activating only the modern APIs when installing Crossplane:
+
+```console
+helm install crossplane crossplane-stable/crossplane \
+  --set provider.defaultActivations={"*.opentelekomcloud.m.crossplane.io"} \
+-n crossplane-system
+```
+
+If any of the legacy APIs are required you can activate them one-by-one
+
+```diff
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: otc-modern-resources
+spec:
+  activate:
+    - "*.opentelekomcloud.m.crossplane.io"
++    - "instancev1s.ecs.opentelekomcloud.crossplane.io"
+```
+
+


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Update the quick start guide so first time users dont have hundreds of legacy APIs and controllers activated by default.
Small document about activating legacy APIs.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed the provider's [contribution process](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file).
- [x] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. We are running upbound e2e testing framework, please read our [guide](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) before opening the PR.
-->

#### [E2E testing](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) is required for the following services:

- [x] `noop`

