### PR TITLE
tests: run tests one by one instead of merging them together

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -140,17 +140,25 @@ jobs:
         id: run-uptest
         env:
           UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
-          UPTEST_EXAMPLE_LIST: ${{ needs.get-example-list.outputs.example_list }}
+          #UPTEST_EXAMPLE_LIST: ${{ needs.get-example-list.outputs.example_list }}
+          EXAMPLE_LIST: ${{ needs.get-example-list.outputs.example_list }}
           UPTEST_TEST_DIR: ./_output/controlplane-dump
           UPTEST_DATASOURCE_PATH: .work/uptest-datasource.yaml
           UPTEST_UPDATE_PARAMETER: ""
           UPTEST_DEFAULT_TIMEOUT: ${{ vars.UPTEST_DEFAULT_TIMEOUT }}
           UPTEST_SKIP_IMPORT: ${{ vars.UPTEST_SKIP_IMPORT }}
         run: |
+          # UPTEST merges all examples into one test case which leads a huge amount of created resources at the same time
+          # also resources are not removed before each example but only at the end
+          # rather then flattening and running make e2e we can just call make local-deploy and then run make uptest one by one
           echo "Timeout is $UPTEST_DEFAULT_TIMEOUT"
           echo "UPTEST_SKIP_IMPORT is $UPTEST_SKIP_IMPORT"
           mkdir -p .work && echo "${{ secrets.UPTEST_DATASOURCE }}" > .work/uptest-datasource.yaml
-          make e2e
+          make local-deploy
+          for EXAMPLE in $(echo "${EXAMPLE_LIST}" | tr ',' ' '); do
+            echo "Running uptest for: $EXAMPLE"
+            UPTEST_EXAMPLE_LIST="$EXAMPLE" make uptest
+          done
 
       - name: Create Successful Status Check
         env:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

`UPTEST` merges all examples into one test case which leads a huge amount of created resources at the same time. Also resources are not removed before each example but only at the end
rather then flattening and running `make e2e` we can just call `make local-deploy` and then run `make uptest` one by one on each test example. like:

```bash
EXAMPLE_LIST="examples/namespaced/identity/aclv3.yaml,examples/namespaced/identity/usersv3.yaml" ; \
 for EXAMPLE in $(echo "${EXAMPLE_LIST}" | tr ',' ' '); \
 do echo "Running uptest for: $EXAMPLE" && \
 echo "UPTEST_EXAMPLE_LIST=$EXAMPLE make uptest"; done
Running uptest for: examples/namespaced/identity/aclv3.yaml
UPTEST_EXAMPLE_LIST=examples/namespaced/identity/aclv3.yaml make uptest
Running uptest for: examples/namespaced/identity/usersv3.yaml
UPTEST_EXAMPLE_LIST=examples/namespaced/identity/usersv3.yaml make uptest
```
 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed the provider's [contribution process](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file).
- [x] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested

Cannot really test it without merging to main but bash example shows what will run.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. We are running upbound e2e testing framework, please read our [guide](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) before opening the PR.
-->

#### [E2E testing](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) is required for the following services:

- [x] `noop`

