### PR TITLE
introduce new vars for multiregion-tests

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Run Nightly Tests
         id: run-nightly-test
         env:
+          UPTEST_CLOUD_CREDENTIALS_DE: ${{ secrets.UPTEST_CLOUD_CREDENTIALS_DE }}
+          UPTEST_CLOUD_CREDENTIALS_NL: ${{ secrets.UPTEST_CLOUD_CREDENTIALS_NL }}
           UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
           UPTEST_DATASOURCE_PATH: .work/uptest-datasource.yaml
           UPTEST_TEST_DIR: ./_output/controlplane-dump

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -140,6 +140,8 @@ jobs:
         id: run-uptest
         env:
           UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
+          UPTEST_CLOUD_CREDENTIALS_DE: ${{ secrets.UPTEST_CLOUD_CREDENTIALS_DE }}
+          UPTEST_CLOUD_CREDENTIALS_NL: ${{ secrets.UPTEST_CLOUD_CREDENTIALS_NL }}
           #UPTEST_EXAMPLE_LIST: ${{ needs.get-example-list.outputs.example_list }}
           EXAMPLE_LIST: ${{ needs.get-example-list.outputs.example_list }}
           UPTEST_TEST_DIR: ./_output/controlplane-dump


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

https://github.com/opentelekomcloud/provider-opentelekomcloud/pull/142 will introduce testing over multiple regions, which is needed for resources like `bucketreplication`. I need to make these new github secrets available for testing.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed the provider's [contribution process](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file).
- [x] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. We are running upbound e2e testing framework, please read our [guide](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) before opening the PR.
-->

#### [E2E testing](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) is required for the following services:

- [x] `noop`

