### PR TITLE
chore: upgrade golangci-lint@v2.12.2 and add constants for repeated tf resource names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   # Common versions
   GO_VERSION: "1.24.1"
-  GOLANGCI_VERSION: "v2.3.1"
+  GOLANGCI_VERSION: "v2.12.2"
   DOCKER_BUILDX_VERSION: "v0.28.0"
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_REQUIRED_VERSION ?= 1.24
-GOLANGCILINT_VERSION ?= 2.4.0
+GOLANGCILINT_VERSION ?= 2.12.2
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis

--- a/config/cluster/cce/config.go
+++ b/config/cluster/cce/config.go
@@ -7,6 +7,10 @@ import (
 	"github.com/opentelekomcloud/provider-opentelekomcloud/config/common"
 )
 
+const (
+	tfVpcSubnetV1 = "opentelekomcloud_vpc_subnet_v1"
+)
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_cce_cluster_v3", func(r *config.Resource) {
@@ -15,19 +19,19 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_vpc_v1",
 		}
 		r.References["subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.NetworkIDExtractor,
 		}
 		r.References["highway_subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.NetworkIDExtractor,
 		}
 		r.References["eni_subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.SubnetIDExtractor,
 		}
 		r.References["eni_subnet_cidr"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.SubnetCIDRExtractor,
 		}
 		r.References["eip"] = config.Reference{
@@ -109,7 +113,7 @@ func Configure(p *config.Provider) {
 			Extractor:     common.AgencyNameExtractor,
 		}
 		r.References["subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.NetworkIDExtractor,
 		}
 	})

--- a/config/cluster/lb/config.go
+++ b/config/cluster/lb/config.go
@@ -6,6 +6,11 @@ import (
 	"github.com/opentelekomcloud/provider-opentelekomcloud/config/common"
 )
 
+const (
+	tfLbPoolV3          = "opentelekomcloud_lb_pool_v3"
+	tfIdentityProjectV3 = "opentelekomcloud_identity_project_v3"
+)
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_loadbalancer_v3", func(r *config.Resource) {
@@ -33,7 +38,7 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_lb_certificate_v3",
 		}
 		r.References["default_pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["ip_group.id"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_ipgroup_v3",
@@ -45,7 +50,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_pool_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["listener_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_listener_v3",
@@ -60,10 +65,10 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_member_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["subnet_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_vpc_subnet_v1",
@@ -72,7 +77,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_ipgroup_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["ip_list.ip"] = config.Reference{
 			TerraformName: "opentelekomcloud_vpc_eip_v1",
@@ -82,16 +87,16 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_monitor_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_lb_policy_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["listener_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_listener_v3",
@@ -100,10 +105,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_lb_listener_v3",
 		}
 		r.References["redirect_pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["redirect_pools_config.pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_lb_rule_v3", func(r *config.Resource) {
@@ -112,13 +117,13 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_lb_policy_v3",
 		}
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_lb_security_policy_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["listener_ids"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_listener_v3",

--- a/config/cluster/vpc/config.go
+++ b/config/cluster/vpc/config.go
@@ -2,12 +2,16 @@ package vpc
 
 import "github.com/crossplane/upjet/v2/pkg/config"
 
+const (
+	tfVpcV1 = "opentelekomcloud_vpc_v1"
+)
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_subnet_v1", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_v1", func(r *config.Resource) {
@@ -26,7 +30,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_flow_log_v1", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["resource_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 		r.References["log_group_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_logtank_group_v2",
@@ -38,10 +42,10 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_peering_connection_v2", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 		r.References["peer_vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_peering_connection_accepter_v2", func(r *config.Resource) {
@@ -53,13 +57,13 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_route_v2", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_route_table_v1", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 }

--- a/config/namespaced/cce/config.go
+++ b/config/namespaced/cce/config.go
@@ -7,6 +7,10 @@ import (
 	"github.com/opentelekomcloud/provider-opentelekomcloud/config/common"
 )
 
+const (
+	tfVpcSubnetV1 = "opentelekomcloud_vpc_subnet_v1"
+)
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_cce_cluster_v3", func(r *config.Resource) {
@@ -15,19 +19,19 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_vpc_v1",
 		}
 		r.References["subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.NetworkIDExtractor,
 		}
 		r.References["highway_subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.NetworkIDExtractor,
 		}
 		r.References["eni_subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.SubnetIDExtractor,
 		}
 		r.References["eni_subnet_cidr"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.SubnetCIDRExtractor,
 		}
 		r.References["eip"] = config.Reference{
@@ -109,7 +113,7 @@ func Configure(p *config.Provider) {
 			Extractor:     common.AgencyNameExtractor,
 		}
 		r.References["subnet_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_subnet_v1",
+			TerraformName: tfVpcSubnetV1,
 			Extractor:     common.NetworkIDExtractor,
 		}
 	})

--- a/config/namespaced/lb/config.go
+++ b/config/namespaced/lb/config.go
@@ -6,6 +6,11 @@ import (
 	"github.com/opentelekomcloud/provider-opentelekomcloud/config/common"
 )
 
+const (
+	tfLbPoolV3          = "opentelekomcloud_lb_pool_v3"
+	tfIdentityProjectV3 = "opentelekomcloud_identity_project_v3"
+)
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_loadbalancer_v3", func(r *config.Resource) {
@@ -33,7 +38,7 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_lb_certificate_v3",
 		}
 		r.References["default_pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["ip_group.id"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_ipgroup_v3",
@@ -45,7 +50,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_pool_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["listener_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_listener_v3",
@@ -60,10 +65,10 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_member_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["subnet_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_vpc_subnet_v1",
@@ -72,7 +77,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_ipgroup_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["ip_list.ip"] = config.Reference{
 			TerraformName: "opentelekomcloud_vpc_eip_v1",
@@ -82,16 +87,16 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_lb_monitor_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_lb_policy_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["listener_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_listener_v3",
@@ -100,10 +105,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_lb_listener_v3",
 		}
 		r.References["redirect_pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 		r.References["redirect_pools_config.pool_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_lb_pool_v3",
+			TerraformName: tfLbPoolV3,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_lb_rule_v3", func(r *config.Resource) {
@@ -112,13 +117,13 @@ func Configure(p *config.Provider) {
 			TerraformName: "opentelekomcloud_lb_policy_v3",
 		}
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_lb_security_policy_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["project_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_identity_project_v3",
+			TerraformName: tfIdentityProjectV3,
 		}
 		r.References["listener_ids"] = config.Reference{
 			TerraformName: "opentelekomcloud_lb_listener_v3",

--- a/config/namespaced/vpc/config.go
+++ b/config/namespaced/vpc/config.go
@@ -2,12 +2,16 @@ package vpc
 
 import "github.com/crossplane/upjet/v2/pkg/config"
 
+const (
+	tfVpcV1 = "opentelekomcloud_vpc_v1"
+)
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_subnet_v1", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_v1", func(r *config.Resource) {
@@ -26,7 +30,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_flow_log_v1", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["resource_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 		r.References["log_group_id"] = config.Reference{
 			TerraformName: "opentelekomcloud_logtank_group_v2",
@@ -38,10 +42,10 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_peering_connection_v2", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 		r.References["peer_vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_peering_connection_accepter_v2", func(r *config.Resource) {
@@ -53,19 +57,19 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_vpc_route_v2", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_route_table_v1", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_secondary_cidr_v3", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["vpc_id"] = config.Reference{
-			TerraformName: "opentelekomcloud_vpc_v1",
+			TerraformName: tfVpcV1,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_vpc_secgroup_rule_v3", func(r *config.Resource) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

`golangci-lint` version is too old for #128 , since its defined in `ci.yml` we need to merge this then rebase dependabot PR.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #138 

I have:

- [x] Read and followed the provider's [contribution process](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file).
- [x] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. We are running upbound e2e testing framework, please read our [guide](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) before opening the PR.
-->

#### [E2E testing](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) is required for the following services:

- [x] `noop`

