### PR TITLE
fix nameSelector and e2e for `instancev2.compute`

### DIFF
--- a/apis/namespaced/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/compute/v1alpha1/zz_generated.deepcopy.go
@@ -1579,6 +1579,16 @@ func (in *NetworkInitParameters) DeepCopyInto(out *NetworkInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NameRef != nil {
+		in, out := &in.NameRef, &out.NameRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.NameSelector != nil {
+		in, out := &in.NameSelector, &out.NameSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
 		*out = new(string)
@@ -1683,6 +1693,16 @@ func (in *NetworkParameters) DeepCopyInto(out *NetworkParameters) {
 		in, out := &in.Name, &out.Name
 		*out = new(string)
 		**out = **in
+	}
+	if in.NameRef != nil {
+		in, out := &in.NameRef, &out.NameRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.NameSelector != nil {
+		in, out := &in.NameSelector, &out.NameSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port

--- a/apis/namespaced/compute/v1alpha1/zz_generated.resolvers.go
+++ b/apis/namespaced/compute/v1alpha1/zz_generated.resolvers.go
@@ -140,6 +140,25 @@ func (mg *InstanceV2) ResolveReferences(ctx context.Context, c client.Reader) er
 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Network); i3++ {
 		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network[i3].Name),
+			Extract:      common.ExtractNetworkingNetworkName(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.Network[i3].NameRef,
+			Selector:     mg.Spec.ForProvider.Network[i3].NameSelector,
+			To: reference.To{
+				List:    &v1alpha1.NetworkV2List{},
+				Managed: &v1alpha1.NetworkV2{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.ForProvider.Network[i3].Name")
+		}
+		mg.Spec.ForProvider.Network[i3].Name = reference.ToPtrValue(rsp.ResolvedValue)
+		mg.Spec.ForProvider.Network[i3].NameRef = rsp.ResolvedReference
+
+	}
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.Network); i3++ {
+		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network[i3].UUID),
 			Extract:      reference.ExternalName(),
 			Namespace:    mg.GetNamespace(),
@@ -210,6 +229,25 @@ func (mg *InstanceV2) ResolveReferences(ctx context.Context, c client.Reader) er
 	mg.Spec.InitProvider.KeyPair = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.InitProvider.KeyPairRef = rsp.ResolvedReference
 
+	for i3 := 0; i3 < len(mg.Spec.InitProvider.Network); i3++ {
+		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Network[i3].Name),
+			Extract:      common.ExtractNetworkingNetworkName(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.Network[i3].NameRef,
+			Selector:     mg.Spec.InitProvider.Network[i3].NameSelector,
+			To: reference.To{
+				List:    &v1alpha1.NetworkV2List{},
+				Managed: &v1alpha1.NetworkV2{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.InitProvider.Network[i3].Name")
+		}
+		mg.Spec.InitProvider.Network[i3].Name = reference.ToPtrValue(rsp.ResolvedValue)
+		mg.Spec.InitProvider.Network[i3].NameRef = rsp.ResolvedReference
+
+	}
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Network); i3++ {
 		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Network[i3].UUID),

--- a/apis/namespaced/compute/v1alpha1/zz_instancev2_types.go
+++ b/apis/namespaced/compute/v1alpha1/zz_instancev2_types.go
@@ -506,7 +506,17 @@ type NetworkInitParameters struct {
 
 	// The human-readable name of the network. Changing this creates
 	// a new server.
+	// +crossplane:generate:reference:type=github.com/opentelekomcloud/provider-opentelekomcloud/apis/namespaced/networking/v1alpha1.NetworkV2
+	// +crossplane:generate:reference:extractor=github.com/opentelekomcloud/provider-opentelekomcloud/config/common.ExtractNetworkingNetworkName()
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
+	// Reference to a NetworkV2 in networking to populate name.
+	// +kubebuilder:validation:Optional
+	NameRef *v1.NamespacedReference `json:"nameRef,omitempty" tf:"-"`
+
+	// Selector for a NetworkV2 in networking to populate name.
+	// +kubebuilder:validation:Optional
+	NameSelector *v1.NamespacedSelector `json:"nameSelector,omitempty" tf:"-"`
 
 	// The port UUID of a network to attach to the server. Changing
 	// this creates a new server.
@@ -574,8 +584,18 @@ type NetworkParameters struct {
 
 	// The human-readable name of the network. Changing this creates
 	// a new server.
+	// +crossplane:generate:reference:type=github.com/opentelekomcloud/provider-opentelekomcloud/apis/namespaced/networking/v1alpha1.NetworkV2
+	// +crossplane:generate:reference:extractor=github.com/opentelekomcloud/provider-opentelekomcloud/config/common.ExtractNetworkingNetworkName()
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
+	// Reference to a NetworkV2 in networking to populate name.
+	// +kubebuilder:validation:Optional
+	NameRef *v1.NamespacedReference `json:"nameRef,omitempty" tf:"-"`
+
+	// Selector for a NetworkV2 in networking to populate name.
+	// +kubebuilder:validation:Optional
+	NameSelector *v1.NamespacedSelector `json:"nameSelector,omitempty" tf:"-"`
 
 	// The port UUID of a network to attach to the server. Changing
 	// this creates a new server.

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -50,7 +50,7 @@ const (
 	// in this package.
 	UsernameExtractor = SelfPackagePath + ".ExtractUsername()"
 
-	NetworkingNetworkExtractor = SelfPackagePath + ".ExtractNetworkingNetworkName()"
+	NetworkingNetworkNameExtractor = SelfPackagePath + ".ExtractNetworkingNetworkName()"
 )
 
 // getStringFromMap safely returns a non-empty string value for a key.

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -49,6 +49,8 @@ const (
 	// UsernameExtractor is the golang path to ExtractUsername function
 	// in this package.
 	UsernameExtractor = SelfPackagePath + ".ExtractUsername()"
+
+	NetworkingNetworkExtractor = SelfPackagePath + ".ExtractNetworkingNetworkName()"
 )
 
 // getStringFromMap safely returns a non-empty string value for a key.
@@ -91,6 +93,24 @@ func ExtractNetworkID() xpref.ExtractValueFn {
 		}
 
 		if k := o["network_id"]; k != nil {
+			return k.(string)
+		}
+		return ""
+	}
+}
+
+func ExtractNetworkingNetworkName() xpref.ExtractValueFn {
+	return func(mr xpresource.Managed) string {
+		tr, ok := mr.(resource.Observable)
+		if !ok {
+			return ""
+		}
+		o, err := tr.GetObservation()
+		if err != nil {
+			return ""
+		}
+
+		if k := o["name"]; k != nil {
 			return k.(string)
 		}
 		return ""

--- a/config/namespaced/compute/config.go
+++ b/config/namespaced/compute/config.go
@@ -22,6 +22,10 @@ func Configure(p *config.Provider) {
 		r.References["network.uuid"] = config.Reference{
 			TerraformName: "opentelekomcloud_networking_network_v2",
 		}
+		r.References["network.name"] = config.Reference{
+			TerraformName: "opentelekomcloud_networking_network_v2",
+			Extractor:     common.NetworkingNetworkExtractor,
+		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_compute_keypair_v2", func(r *config.Resource) {
 		r.UseAsync = true

--- a/config/namespaced/compute/config.go
+++ b/config/namespaced/compute/config.go
@@ -24,7 +24,7 @@ func Configure(p *config.Provider) {
 		}
 		r.References["network.name"] = config.Reference{
 			TerraformName: "opentelekomcloud_networking_network_v2",
-			Extractor:     common.NetworkingNetworkExtractor,
+			Extractor:     common.NetworkingNetworkNameExtractor,
 		}
 	})
 	p.AddResourceConfigurator("opentelekomcloud_compute_keypair_v2", func(r *config.Resource) {

--- a/examples-generated/namespaced/compute/v1alpha1/instancev2.yaml
+++ b/examples-generated/namespaced/compute/v1alpha1/instancev2.yaml
@@ -18,7 +18,9 @@ spec:
       this: that
     name: basic
     network:
-    - name: my_network
+    - nameSelector:
+        matchLabels:
+          testing.upbound.io/example-name: example
     securityGroupsRefs:
     - name: example
     tags:

--- a/examples/namespaced/compute/instance.yaml
+++ b/examples/namespaced/compute/instance.yaml
@@ -11,7 +11,6 @@ spec:
   forProvider:
     adminStateUp: "true"
     name: xp-test-${Rand.RFC1123Subdomain}
-
 ---
 apiVersion: networking.opentelekomcloud.m.crossplane.io/v1alpha1
 kind: RouterV2
@@ -98,7 +97,9 @@ spec:
     imageId: 765aeae4-7c4a-4bc7-93ff-ad1daa9c2fda
     name: xp-test-${Rand.RFC1123Subdomain}
     network:
-      - name: crossplane_network
+      - nameSelector:
+          matchLabels:
+            testing.upbound.io/example-name: sample-network
 
 ---
 apiVersion: networking.opentelekomcloud.m.crossplane.io/v1alpha1

--- a/package/crds/compute.opentelekomcloud.m.crossplane.io_instancev2s.yaml
+++ b/package/crds/compute.opentelekomcloud.m.crossplane.io_instancev2s.yaml
@@ -371,6 +371,88 @@ spec:
                             The human-readable name of the network. Changing this creates
                             a new server.
                           type: string
+                        nameRef:
+                          description: Reference to a NetworkV2 in networking to populate
+                            name.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            namespace:
+                              description: Namespace of the referenced object
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        nameSelector:
+                          description: Selector for a NetworkV2 in networking to populate
+                            name.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            namespace:
+                              description: Namespace for the selector
+                              type: string
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         port:
                           description: |-
                             The port UUID of a network to attach to the server. Changing
@@ -966,6 +1048,88 @@ spec:
                             The human-readable name of the network. Changing this creates
                             a new server.
                           type: string
+                        nameRef:
+                          description: Reference to a NetworkV2 in networking to populate
+                            name.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            namespace:
+                              description: Namespace of the referenced object
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        nameSelector:
+                          description: Selector for a NetworkV2 in networking to populate
+                            name.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            namespace:
+                              description: Namespace for the selector
+                              type: string
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         port:
                           description: |-
                             The port UUID of a network to attach to the server. Changing


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Name based selector was missing for `instancev2.compute` which fails e2e testing.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #152 

I have:

- [x] Read and followed the provider's [contribution process](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file).
- [x] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. We are running upbound e2e testing framework, please read our [guide](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) before opening the PR.
-->

#### [E2E testing](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) is required for the following services:

- [x] `examples/namespaced/compute/instance.yaml` [✅](https://github.com/opentelekomcloud/provider-opentelekomcloud/actions/runs/31581951188)

