### PR TITLE
fix(linter): golangci-lint `goconst` errors in OBS conf

### DIFF
--- a/config/namespaced/obs/config.go
+++ b/config/namespaced/obs/config.go
@@ -6,8 +6,12 @@ import (
 	"github.com/opentelekomcloud/provider-opentelekomcloud/config/common"
 )
 
+const (
+	tfObsBucket = "opentelekomcloud_obs_bucket"
+)
+
 func Configure(p *config.Provider) {
-	p.AddResourceConfigurator("opentelekomcloud_obs_bucket", func(r *config.Resource) {
+	p.AddResourceConfigurator(tfObsBucket, func(r *config.Resource) {
 		// ACL in terraform provider - The acl argument manages supported canned ACLs only: private, public-read, public-read-write, and log-delivery-write. Drift for those canned ACLs is detected on refresh. If the bucket is managed with a custom ACL grant set, use opentelekomcloud_obs_bucket_acl instead of the inline acl argument.
 		config.MoveToStatus(r.TerraformResource, "acl")
 		r.MetaResource.ArgumentDocs["acl"] = `Deprecated, defaults to ACL=private. Use bucketacls.obs.opentelekomcloud.m.crossplane.io for ACL management. buckets.obs.opentelekomcloud.m.crossplane.io can only observe ACL state, but cannot change it.`
@@ -15,7 +19,7 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"acl"},
 		}
 		r.References["logging.target_bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.References["logging.agency"] = config.Reference{
@@ -35,18 +39,18 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("opentelekomcloud_obs_bucket_acl", func(r *config.Resource) {
 		r.MetaResource.Description = `Manages an OBS bucket acl resource within OpenTelekomCloud. For proper functionality need to configure domain_id in credentials.`
 		r.References["bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("opentelekomcloud_obs_bucket_inventory", func(r *config.Resource) {
 		r.References["bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.References["destination.bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 	})
@@ -59,7 +63,7 @@ func Configure(p *config.Provider) {
 		}
 
 		r.References["bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.References["sse_kms_key_id"] = config.Reference{
@@ -71,7 +75,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("opentelekomcloud_obs_bucket_object_acl", func(r *config.Resource) {
 		r.References["bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.References["key"] = config.Reference{
@@ -81,7 +85,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("opentelekomcloud_obs_bucket_policy", func(r *config.Resource) {
 		r.References["bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.MetaResource.ArgumentDocs["policy"] = `The text of the policy. Supports dynamic value substitution for Resource using the placeholder ${this.bucket} which will be replaced with the resolved bucket name from spec.forProvider.bucketSelector. Example: "Resource": ["${this.bucket}/*"]. Alternatively if you choose to configure a different bucket you need to provide bucket/resource as a string. Example: "Resource": ["mybucket/*"]`
@@ -95,11 +99,11 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("opentelekomcloud_obs_bucket_replication", func(r *config.Resource) {
 		r.References["bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.References["destination_bucket"] = config.Reference{
-			TerraformName: "opentelekomcloud_obs_bucket",
+			TerraformName: tfObsBucket,
 			Extractor:     common.ObsBucketExtractor,
 		}
 		r.References["agency"] = config.Reference{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

New version of `golangci-lint` introduced some `goconst` errors. This small PR fixes that.

```console
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint run] in [/home/runner/work/provider-opentelekomcloud/provider-opentelekomcloud] ...
  Error: config/namespaced/obs/config.go:18:19: string `opentelekomcloud_obs_bucket` has 9 occurrences, make it a constant (goconst)
  			TerraformName: "opentelekomcloud_obs_bucket",
  			               ^
  1 issues:
  * goconst: 1
  
  Error: issues found
  Ran golangci-lint in 143486ms
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed the provider's [contribution process](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file).
- [x] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. We are running upbound e2e testing framework, please read our [guide](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) before opening the PR.
-->

#### [E2E testing](https://github.com/opentelekomcloud/provider-opentelekomcloud?tab=contributing-ov-file#integration-testing) is required for the following services:

- [x] `noop`

